### PR TITLE
2021 Festival of the Lost + 30th Anniversary Dates

### DIFF
--- a/src/app/pipes/milestone.pipe.ts
+++ b/src/app/pipes/milestone.pipe.ts
@@ -39,6 +39,8 @@ export class MilestonePipe implements PipeTransform {
           case '2021-08-24':
           case '2021-2-22':
           case '2021-02-22':
+          case '2021-12-7':
+          case '2021-12-07':
             return 'release'
           case '2017-9-13':
           case '2017-09-13':
@@ -174,6 +176,7 @@ export class MilestonePipe implements PipeTransform {
           case '2021-08-31':
           case '2021-9-7':
           case '2021-09-07':
+          case '2021-10-12':
             return 'event'
           default:
             return ''
@@ -411,6 +414,11 @@ export class MilestonePipe implements PipeTransform {
           case '2021-9-7':
           case '2021-09-07':
             return ' | Shattered Realm: Ruins of Wrath'
+          case '2021-10-12':
+            return ' | Festival of the Lost'
+          case '2021-12-7':
+          case '2021-12-07':
+            return ' | Bungie 30th Anniversary Expansion'
           case '2022-2-22':
           case '2021-02-22':
             return ' | Launch: The Witch Queen'


### PR DESCRIPTION
They aren't doing any favors with calendar dates so just adding these as they go. Next week is Festival of the Lost, also added the date Steam lists as the release of the 30th Anniversary Expansion